### PR TITLE
Add support for python 3.12

### DIFF
--- a/kojen/Install.py
+++ b/kojen/Install.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
-from .cgen import FileCopyUtil
-from distutils.dir_util import copy_tree
+from .cgen import FileCopyUtil, DirectoryCopyUtil
 import shutil
 
 def getUserTemplateRoot() -> str:
@@ -40,7 +39,7 @@ def InstallTemplates(template_path) -> None:
         if os.path.isfile(template_path):
             FileCopyUtil(os.path.dirname(os.path.abspath(template_path)), getUserTemplateRoot(), [os.path.basename(os.path.abspath(template_path))])
         if os.path.isdir(template_path):
-            copy_tree(os.path.abspath(template_path), getUserTemplateRoot())
+            DirectoryCopyUtil(os.path.abspath(template_path), getUserTemplateRoot())
 
 def UninstallTemplates() -> None:
     """Will uninstall all user templates."""
@@ -68,5 +67,3 @@ def ContainsTemplates(rel_template_path) -> bool:
                 if normpath_file.find(os.path.normpath(rel_template_path)) != -1:
                     return True
     return False
-
-

--- a/kojen/cgen.py
+++ b/kojen/cgen.py
@@ -951,6 +951,19 @@ def FileCopyUtil(dir_from, dir_to, list_of_filenames) -> None:
     except OSError:
         warning("Creation of the directory %s failed" % dir_to)
 
+def DirectoryCopyUtil(dir_from, dir_to) -> None:
+    """
+    Will recursively copy the 'dir_from' directory tree into 'dir_to', merging into
+    (rather than replacing) an already-existing destination. Follows symlinked
+    subdirectories and copies their contents as real directories.
+
+    @param dir_from: The directory tree to copy from.
+    @param dir_to: The directory tree to merge-copy into.
+    """
+    for root, _dirs, files in os.walk(dir_from, followlinks=True):
+        dst_root = os.path.join(dir_to, os.path.relpath(root, dir_from))
+        FileCopyUtil(root, dst_root, files)
+
 def FilePreservationSyncUtil(file_from, file_to) -> None:
     """
     Will synchronize code in preservation tags from 'file_from' to 'file_to',

--- a/kojen/test/install_test.py
+++ b/kojen/test/install_test.py
@@ -76,3 +76,40 @@ class TestInstall(unittest.TestCase):
         UninstallTemplates()
         self.assertFalse(os.path.exists(getUserTemplateRoot()))
 
+    def test_InstallTemplates_MergesWithoutDeletingExisting(self):
+        """A second, unrelated InstallTemplates() call must not delete templates installed
+           by a previous call (merge semantics, not a destructive replace)."""
+        InstallTemplates(self.trash_root)
+
+        other_root = os.path.normpath(os.path.join(os.getcwd(), "trash_other"))
+        os.makedirs(other_root)
+        try:
+            other_file = os.path.join(other_root, "other_file.py")
+            with open(other_file, "w") as file:
+                file.write("#!/usr/bin/env python\n")
+            InstallTemplates(other_root)
+
+            # Original install's files are still present ...
+            for p in self.relative_file_paths:
+                self.assertTrue(ContainsTemplates(p))
+            # ... and the new install's file was added alongside them.
+            self.assertTrue(ContainsTemplates("other_file.py"))
+        finally:
+            shutil.rmtree(other_root)
+
+    def test_InstallTemplates_FollowsSymlinkedDirectories(self):
+        """A symlinked subdirectory must be followed and its contents copied as real
+           files, matching distutils.dir_util.copy_tree()'s default (preserve_symlinks=0)."""
+        real_dir = os.path.join(self.trash_root, "real_dir")
+        os.makedirs(real_dir)
+        with open(os.path.join(real_dir, "inside.py"), "w") as file:
+            file.write("#!/usr/bin/env python\n")
+
+        link_dir = os.path.join(self.trash_root, "link_dir")
+        try:
+            os.symlink(real_dir, link_dir, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            self.skipTest("Symlinks are not supported/permitted in this environment.")
+
+        InstallTemplates(self.trash_root)
+        self.assertTrue(os.path.isfile(os.path.join(getUserTemplateRoot(), "link_dir", "inside.py")))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.MD", "r") as fh:
 
 setuptools.setup(
     name="kojen",
-    version="2.5.77",
+    version="2.5.78",
     author="kohjaen",
     author_email="koh.jaen@yahoo.de",
     description="Code generation tools.",


### PR DESCRIPTION
Distutil is deprecated since python 3.10 and removed in 3.12
In the case of a environment without setuptools, we need to make sure we don't rely on the distutils module